### PR TITLE
fix autolink error that occurs when "See Also" line is succeeded by "--------"

### DIFF
--- a/sphinxcontrib/mat_documenters.py
+++ b/sphinxcontrib/mat_documenters.py
@@ -203,7 +203,8 @@ class MatlabDocumenter(PyDocumenter):
                     if is_see_also_line:
                         # find name
                         match = see_also_cond_re.search(line)
-                        entries_str = match.group(2)  # the entries
+                        if match is not None:
+                            entries_str = match.group(2)  # the entries
                     elif match := see_also_re.search(line):
                         is_see_also_line = True  # line begins with "See also"
                         entries_str = match.group(2)  # the entries


### PR DESCRIPTION
This usually happens when using numpy syntax docstrings, i.e.

```
    % See Also
    % --------
    % some text here
```


The errors looks like this:

```
File "/home/luis/.local/lib/python3.10/site-packages/sphinxcontrib/mat_documenters.py", line 206, in auto_link_see_also
    entries_str = match.group(2)  # the entries
AttributeError: 'NoneType' object has no attribute 'group'
```